### PR TITLE
Change from FindByAttributes to Exists

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -68,5 +68,6 @@ Download this extension (and fork it):
 
 Changelog
 ---------
+* 2014-08-25 Slight speed improvement
 * 2011-04-30 Added _update_ functionality
 * 2011-06-23 Added support for dependent models (see demo configuration, author.name)

--- a/SluggableBehavior.php
+++ b/SluggableBehavior.php
@@ -268,7 +268,7 @@ class SluggableBehavior extends CActiveRecordBehavior
         } else {
             $counter = 0;
             while ($this->getOwner()->resetScope()
-                ->findByAttributes(array($this->slugColumn => $checkslug))
+                ->exists($this->slugColumn.'=:sluggable', array(':sluggable' => $checkslug))
             ) {
                 Yii::trace("$checkslug found, iterating", __CLASS__);
                 $checkslug = sprintf('%s-%d', $slug, ++$counter);


### PR DESCRIPTION
While looking for a good slug, we do not need to create the model, just check for existence. This is a hefty speedup in cases where the counter will be high.